### PR TITLE
Fix Linter code errors in `./Cogs/Fun.py`.

### DIFF
--- a/Cogs/Fun.py
+++ b/Cogs/Fun.py
@@ -1,6 +1,7 @@
 import discord, requests
 from discord.ext import commands
 from random import choice
+import asyncio
 
 
 class Fun(commands.Cog):


### PR DESCRIPTION
The problem(s):
- Linter couldn't find a defined name with `asyncio`.

The fix:
- Import the `asyncio` package in the file.